### PR TITLE
Fix error message checking current line against current line.

### DIFF
--- a/nimporter.py
+++ b/nimporter.py
@@ -49,7 +49,7 @@ class NimCompileException(NimporterException):
             mod, (line_col) = nim_module.split('(')
             nim_module = Path(mod)
             src_line, col = line_col.split(',')
-            src_line = int(line)
+            src_line = int(src_line)
             col = int(col.replace(')', ''))
             message = error_msg + '\n'
 

--- a/nimporter.py
+++ b/nimporter.py
@@ -48,30 +48,30 @@ class NimCompileException(NimporterException):
             nim_module = nim_module.splitlines()[-1]
             mod, (line_col) = nim_module.split('(')
             nim_module = Path(mod)
-            line, col = line_col.split(',')
-            line = int(line)
+            src_line, col = line_col.split(',')
+            src_line = int(line)
             col = int(col.replace(')', ''))
             message = error_msg + '\n'
-            
+
             with open(nim_module, 'r') as mod:
                 line = 0
                 for each_line in mod:
                     line += 1
 
-                    if line == line:
+                    if line == src_line:
                         message += f' -> {each_line}'
-                        
-                    elif line > line + 2:
+
+                    elif line > src_line + 2:
                         break
-                    
-                    elif line > line - 3:
+
+                    elif line > src_line - 3:
                         message += f' |  {each_line}'
 
             self.message = message.rstrip() + (
                 f'\n\nAt {nim_module.absolute()} '
                 f'{line}:{col}'
             )
-        
+
     def __str__(self):
         "Return the string representation of the given compiler error."
         return self.message


### PR DESCRIPTION
It seems like 

```
            line, col = line_col.split(',')
            line = int(line)
```
 
in the NimCompileException initializer, followed by 

```
                line = 0
                for each_line in mod:
                    line += 1

                    if line == line:
                        message += f' -> {each_line}'

                    elif line > line + 2:
                        break

                    elif line > line - 3:
                        message += f' |  {each_line}'	
```

would have the effect of adding every single line in the module to the error message, since we're testing against line, so I just changed it to test against the line in the initial error message.