### PR TITLE
Update nimporter.py

### DIFF
--- a/nimporter.py
+++ b/nimporter.py
@@ -184,8 +184,8 @@ class NimCompiler:
             nim_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
         out, err = process.stdout, process.stderr
-        out = out.decode() if out else ''
-        err = err.decode() if err else ''
+        out = out.decode(errors='ignore') if out else ''
+        err = err.decode(errors='ignore') if err else ''
         lines = (out + err).splitlines()
 
         errors   = [line for line in lines if 'Error:' in line]


### PR DESCRIPTION
quick-and-dirty fix on the unicode string problem. Else 
```
  File "E:\prg\py\Anaconda3_64\lib\site-packages\nimporter.py", line 188, in invoke_compiler
    out = out.decode() if out else ''
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd5 in position 2: invalid continuation byte
```