### PR TITLE
Check if the user is using 64Bit Python

### DIFF
--- a/nimporter_cli.py
+++ b/nimporter_cli.py
@@ -11,9 +11,11 @@ SETUPPY_TEMPLATE = f"""
 # https://github.com/navdeep-G/setup.py
 # Edit `packages=` to fit your requirements
 
-import setuptools, pathlib, sysconfig
+import setuptools, pathlib, sysconfig, platform
 from setuptools.command.build_ext import build_ext
 import nimporter
+
+assert platform.architecture()[0] == "64bit", "ERROR: Python must be 64 Bit!." # Delete this line for 32Bit binaries.
 
 class NoSuffixBuilder(build_ext):
     # NO Suffix: module.linux-x86_64.cpython.3.8.5.so --> module.so


### PR DESCRIPTION
- Add a check for 64Bit Python to the `setup.py`  template (32Bit binaries are slower).

Sometimes noobs install 32Bit Nim or 32Bit Python on 64Bit OS, no new 32Bit hardware for PC been built since the 90's.

Some people come from scripting interpreted languages, and been using 32Bit out of habit until today,
when your code runs inside a virtual machine theres no difference, but for native machine code it does.

Nowadays all PC are 64Bit hardware, theres no modern 32Bit PC, most likely they should be using 64Bit.
